### PR TITLE
Ensure Tcl/Tk-8.x and update to Platform 24.08

### DIFF
--- a/info.puredata.Pd.yml
+++ b/info.puredata.Pd.yml
@@ -20,6 +20,8 @@ rename-icon: puredata
 rename-appdata-file: org.puredata.pd-gui.metainfo.xml
 rename-desktop-file: org.puredata.pd-gui.desktop
 modules:
+  - modules/tcl.json
+  - modules/tk.json
   - name: pd64
     buildsystem: autotools
     config-opts:

--- a/info.puredata.Pd.yml
+++ b/info.puredata.Pd.yml
@@ -1,6 +1,6 @@
 app-id: info.puredata.Pd
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: pd-gui
 finish-args:
@@ -20,8 +20,6 @@ rename-icon: puredata
 rename-appdata-file: org.puredata.pd-gui.metainfo.xml
 rename-desktop-file: org.puredata.pd-gui.desktop
 modules:
-  - modules/tcl.json
-  - modules/tk.json
   - name: pd64
     buildsystem: autotools
     config-opts:


### PR DESCRIPTION
- Updates to `runtime/org.freedesktop.Platform/x86_64/24.08`
  - we do not use the Tcl/Tk that comes with the runtime, as this provides a `wish8.6` binary, and we really need a `wish` binary. I'd rather not patch `pd-gui.tcl`. LATER check if we can just provide a small wrapper-script that calls the latest and greatest `wish8.*`
- Tell the version-checker to only look for versions `<<9`
