### PR TITLE
Limit Tcl/Tk versions to 8.x

### DIFF
--- a/modules/tcl.json
+++ b/modules/tcl.json
@@ -14,6 +14,7 @@
                 "type": "anitya",
                 "project-id": 4941,
                 "stable-only": true,
+                "versions": {"<": "9"},
                 "url-template": "https://prdownloads.sourceforge.net/tcl/tcl$version-src.tar.gz"
             }
         }

--- a/modules/tk.json
+++ b/modules/tk.json
@@ -17,6 +17,7 @@
                 "type": "anitya",
                 "project-id": 11426,
                 "stable-only": true,
+                "versions": {"<": "9"},
                 "url-template": "https://prdownloads.sourceforge.net/tcl/tk$version-src.tar.gz"
             }
         }


### PR DESCRIPTION
to shut up the external-data-checker